### PR TITLE
Use cloudconfig parameter to load azure cloud config file

### DIFF
--- a/cmd/azure-keyvault-controller/main.go
+++ b/cmd/azure-keyvault-controller/main.go
@@ -123,7 +123,7 @@ func main() {
 			log.Fatalf("failed to create azure key vault credentials, error: %+v", err.Error())
 		}
 	} else {
-		if vaultAuth, err = vault.NewAzureKeyVaultCredentialsFromCloudConfig("/etc/kubernetes/azure.json"); err != nil {
+		if vaultAuth, err = vault.NewAzureKeyVaultCredentialsFromCloudConfig(cloudconfig); err != nil {
 			log.Fatalf("failed to create azure key vault credentials, error: %+v", err.Error())
 		}
 	}


### PR DESCRIPTION
The `-cloudconfig` flag was documented but the default location was used even when this argument specified a different file location.