### PR TITLE
Keep startup directory intact until execution

### DIFF
--- a/cmd/azure-keyvault-env/main.go
+++ b/cmd/azure-keyvault-env/main.go
@@ -93,12 +93,7 @@ func main() {
 
 	vaultService := vault.NewService(creds)
 
-	// Delete /azure-keyvault/
-	dirToRemove := "/azure-keyvault/"
-	log.Debugf("%s deleting directory '%s'", logPrefix, dirToRemove)
-	if clearDir(dirToRemove) != nil {
-		log.Fatalf("%s error removing directory '%s' : %s", logPrefix, dirToRemove, err.Error())
-	}
+	// Deletion used to be here
 
 	log.Debugf("%s reading azurekeyvaultsecret's referenced in env variables", logPrefix)
 	cfg, err := rest.InClusterConfig()
@@ -165,6 +160,10 @@ func main() {
 		if err != nil {
 			log.Fatalf("%s binary not found: %s", logPrefix, os.Args[1])
 		}
+
+		// Remove potentially sensitive files
+		deleteSensitiveFiles()
+
 		log.Infof("starting process %s %v", binary, os.Args[1:])
 		err = syscall.Exec(binary, os.Args[1:], environ)
 		if err != nil {
@@ -175,6 +174,15 @@ func main() {
 
 	log.Debugf("%s azure key vault env injector successfully injected env variables with secrets", logPrefix)
 	log.Debugf("%s azure key vault env injector", logPrefix)
+}
+
+func deleteSensitiveFiles() {
+	dirToRemove := "/azure-keyvault/"
+	log.Debugf("%s deleting directory '%s'", logPrefix, dirToRemove)
+	err := clearDir(dirToRemove)
+	if err != nil {
+		log.Fatalf("%s error removing directory '%s' : %s", logPrefix, dirToRemove, err.Error())
+	}
 }
 
 func clearDir(dir string) error {


### PR DESCRIPTION
Move CleanDir down the execution sequence to avoid missing file
exception when running in a K8s pod.

If cleanup is called earlier, the following exception occurs: 
```Error: failed to start container "net-testutils": Error response from daemon: OCI runtime create failed: container_linux.go:345: starting container process caused "exec: \"/azure-keyvault/azure-keyvault-env\": stat /azure-keyvault/azure-keyvault-env: no such file or directory": unknown```