### PR TITLE
Keep startup dir intact unitl exec & fix non root permission

### DIFF
--- a/cmd/azure-keyvault-env/main.go
+++ b/cmd/azure-keyvault-env/main.go
@@ -93,14 +93,6 @@ func main() {
 
 	vaultService := vault.NewService(creds)
 
-	// Delete /azure-keyvault/
-	dirToRemove := "/azure-keyvault/"
-	log.Debugf("%s deleting directory '%s'", logPrefix, dirToRemove)
-	err = clearDir(dirToRemove)
-	if err != nil {
-		log.Errorf("%s error removing directory '%s' : %s", logPrefix, dirToRemove, err.Error())
-	}
-
 	log.Debugf("%s reading azurekeyvaultsecret's referenced in env variables", logPrefix)
 	cfg, err := rest.InClusterConfig()
 	if err != nil {
@@ -166,6 +158,10 @@ func main() {
 		if err != nil {
 			log.Fatalf("%s binary not found: %s", logPrefix, os.Args[1])
 		}
+
+		// Remove potentially sensitive files
+		deleteSensitiveFiles()
+
 		log.Infof("starting process %s %v", binary, os.Args[1:])
 		err = syscall.Exec(binary, os.Args[1:], environ)
 		if err != nil {
@@ -176,6 +172,15 @@ func main() {
 
 	log.Debugf("%s azure key vault env injector successfully injected env variables with secrets", logPrefix)
 	log.Debugf("%s azure key vault env injector", logPrefix)
+}
+
+func deleteSensitiveFiles() {
+	dirToRemove := "/azure-keyvault/"
+	log.Debugf("%s deleting directory '%s'", logPrefix, dirToRemove)
+	err := clearDir(dirToRemove)
+	if err != nil {
+		log.Fatalf("%s error removing directory '%s' : %s", logPrefix, dirToRemove, err.Error())
+	}
 }
 
 func clearDir(dir string) error {

--- a/cmd/azure-keyvault-secrets-webhook/main.go
+++ b/cmd/azure-keyvault-secrets-webhook/main.go
@@ -89,7 +89,8 @@ func getInitContainers() []corev1.Container {
 
 	if !config.customAuth {
 		cmd = cmd + fmt.Sprintf(" && cp %s %s && ", config.cloudConfigHostPath, config.cloudConfigContainerPath)
-		cmd = cmd + fmt.Sprintf("chmod 444 %s", config.cloudConfigContainerPath)
+		cmd = cmd + fmt.Sprintf("chmod -R a+rw-t %s && ", "/azure-keyvault")
+		cmd = cmd + fmt.Sprintf("chmod a+rwx %s ", "/azure-keyvault/azure-keyvault-env")
 	}
 
 	container := corev1.Container{


### PR DESCRIPTION
* Keep startup directory intact until execution
* Move CleanDir down the execution sequence to avoid missing file
exception when running in a K8s pod
* add nonroot user permission
* rem restricted del sticky bit

Co-authored-by: Pavel <bambriy@users.noreply.github.com>