### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# See: https://help.github.com/en/articles/about-code-owners#codeowners-syntax
+*       @torresdal @vidarw


### PR DESCRIPTION
We now require all repositories within our organization to have CODEOWNERS defined.
I see this repository has a OWNERS file defined, but could not find any documentation on Github that suggests that this is supported or what the difference is compared to CODEOWNERS. Could it be obsolete? Either way the latter would server the same purpose.