### PR TITLE
Add chainOrder to .output.secret in AzureKeyVaultSecret CRD

### DIFF
--- a/crds/AzureKeyVaultSecret.yaml
+++ b/crds/AzureKeyVaultSecret.yaml
@@ -43,6 +43,9 @@ spec:
                 properties:
                   secret:
                     properties:
+                      chainOrder:
+                        description: By setting chainOrder to ensureserverfirst the server certificate will be moved first in the chain
+                        type: string
                       dataKey:
                         description: The key to use in Kubernetes secret when setting the value from Azure Keyv Vault object data
                         type: string
@@ -238,6 +241,9 @@ spec:
                     type: object
                   secret:
                     properties:
+                      chainOrder:
+                        description: By setting chainOrder to ensureserverfirst the server certificate will be moved first in the chain
+                        type: string
                       dataKey:
                         description: The key to use in Kubernetes secret when setting the value from Azure Keyv Vault object data
                         type: string
@@ -349,6 +355,9 @@ spec:
                     type: object
                   secret:
                     properties:
+                      chainOrder:
+                        description: By setting chainOrder to ensureserverfirst the server certificate will be moved first in the chain
+                        type: string
                       dataKey:
                         description: The key to use in Kubernetes secret when setting the value from Azure Keyv Vault object data
                         type: string

--- a/crds/AzureKeyVaultSecret.yaml
+++ b/crds/AzureKeyVaultSecret.yaml
@@ -45,6 +45,8 @@ spec:
                     properties:
                       chainOrder:
                         description: By setting chainOrder to ensureserverfirst the server certificate will be moved first in the chain
+                        enum:
+                        - ensureserverfirst
                         type: string
                       dataKey:
                         description: The key to use in Kubernetes secret when setting the value from Azure Keyv Vault object data
@@ -243,6 +245,8 @@ spec:
                     properties:
                       chainOrder:
                         description: By setting chainOrder to ensureserverfirst the server certificate will be moved first in the chain
+                        enum:
+                        - ensureserverfirst
                         type: string
                       dataKey:
                         description: The key to use in Kubernetes secret when setting the value from Azure Keyv Vault object data
@@ -357,6 +361,8 @@ spec:
                     properties:
                       chainOrder:
                         description: By setting chainOrder to ensureserverfirst the server certificate will be moved first in the chain
+                        enum:
+                        - ensureserverfirst
                         type: string
                       dataKey:
                         description: The key to use in Kubernetes secret when setting the value from Azure Keyv Vault object data


### PR DESCRIPTION
Add chainOrder to .output.secret in AzureKeyVaultSecret CRD, resolves #157

Introduced in api v1, but missing in crd version v1 and v2alpha1