### PR TITLE
Upgrade Alpine and Golang base images to fix OpenSSL Critical Vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASEIMAGE=gcr.io/distroless/static:nonroot
 ARG BASE_ALPINE=alpine:3.14
-ARG GO_VERSION=1.16.5
+ARG GO_VERSION=1.16.9
 
 # -------
 # Builder


### PR DESCRIPTION
This change tracks Golang 1.16.9 and Alpine 3.14.x (currently 3.14.2) to ensure that newer builds include.

The probability of regression between Alpine 3.14.x releases is most likely quite low for this use case, but the ability to ensure releases pull in the latest security patches is worth it.