### PR TITLE
Upgrade to Golang 1.16.12 and improve docker image creation speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 bin
 debug.test
 .vscode
+.idea
 /vendor/
 /tmp/
 /.tools/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASEIMAGE=gcr.io/distroless/static:nonroot
 ARG BASE_ALPINE=alpine:3.14
-ARG GO_VERSION=1.16.9
+ARG GO_VERSION=1.16.12
 
 # -------
 # Builder
@@ -11,8 +11,11 @@ ARG VCS_REF=noref
 ARG BUILD_SUB_TARGET
 
 WORKDIR /go/src/${PACKAGE}
-ADD . .
+
+ADD go.mod go.sum /go/src/${PACKAGE}
 RUN go mod download
+
+ADD . .
 RUN GIT_TAG=${VCS_REF} make build${BUILD_SUB_TARGET}
 
 # ------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,8 @@ ARG GO_VERSION=1.16.12
 # -------
 FROM golang:${GO_VERSION} AS base_builder
 ARG PACKAGE
-ARG VCS_REF=noref
 
 WORKDIR /go/src/${PACKAGE}
-
 ADD go.mod go.sum /go/src/${PACKAGE}
 RUN go mod download
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,21 @@ ARG GO_VERSION=1.16.12
 # -------
 # Builder
 # -------
-FROM golang:${GO_VERSION} AS builder
+FROM golang:${GO_VERSION} AS base_builder
 ARG PACKAGE
 ARG VCS_REF=noref
-ARG BUILD_SUB_TARGET
 
 WORKDIR /go/src/${PACKAGE}
 
 ADD go.mod go.sum /go/src/${PACKAGE}
 RUN go mod download
+
+FROM base_builder AS builder
+ARG PACKAGE
+ARG VCS_REF=noref
+ARG BUILD_SUB_TARGET
+
+WORKDIR /go/src/${PACKAGE}
 
 ADD . .
 RUN GIT_TAG=${VCS_REF} make build${BUILD_SUB_TARGET}


### PR DESCRIPTION
* Update golang 1.16.12 for various security fixes.
* Tweak docker build to avoid running `go mod download` multiple times if go.mod or go.sum hasn't changed. (Useful on slow internet connections as this step can take ~3-5 minutes)