### PR TITLE
Fix: Fallback to the Pod generated name when creating a secret for an unnamed pod

### DIFF
--- a/cmd/azure-keyvault-secrets-webhook/auth/auth.go
+++ b/cmd/azure-keyvault-secrets-webhook/auth/auth.go
@@ -272,6 +272,8 @@ func (a AuthService) NewPodSecret(pod *corev1.Pod, namespace string, mutationID 
 			} else {
 				name = ownerReferences[0].Name
 			}
+		} else {
+			name = pod.GetGenerateName()
 		}
 	}
 


### PR DESCRIPTION
when generating a secret name fall back to the pod generated name if the pod name is not available

Resolves #307