### PR TITLE
Update CRD to apiextensions.k8s.io/v1

### DIFF
--- a/crds/AzureKeyVaultIdentity.yaml
+++ b/crds/AzureKeyVaultIdentity.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: azurekeyvaultidentities.spv.no
@@ -22,12 +22,12 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          required: ['identity']
+      schema:
+        openAPIV3Schema:
           properties:
-            name:
-              type: string
-              description: Name of the Azure Managed Identity
+            spec:
+              required: [ 'identity' ]
+              properties:
+                name:
+                  type: string
+                  description: Name of the Azure Managed Identity to

--- a/crds/AzureManagedIdentity.yaml
+++ b/crds/AzureManagedIdentity.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: azuremanagedidentities.spv.no
@@ -22,12 +22,12 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          required: ['name']
+      schema:
+        openAPIV3Schema:
           properties:
-            name:
-              type: string
-              description: Name of the Azure Managed Identity
+            spec:
+              required: ['name']
+              properties:
+                name:
+                  type: string
+                  description: Name of the Azure Managed Identity to


### PR DESCRIPTION
The apiextensions.k8s.io/v1beta1 version of CustomResourceDefinitions is deprecated in kubernetes 1.22.