### PR TITLE
Fixes secret not found when label selector is set

### DIFF
--- a/cmd/azure-keyvault-controller/main.go
+++ b/cmd/azure-keyvault-controller/main.go
@@ -151,9 +151,6 @@ func main() {
 			m := labels.Merge(curLabelSet, newLabels)
 			return m.String()
 		}
-		kubeInformerOptions = append(kubeInformerOptions, kubeinformers.WithTweakListOptions(func(options *metav1.ListOptions) {
-			options.LabelSelector = labelSelectorAppender(options.LabelSelector, objectLabelSet)
-		}))
 		akvInformerOptions = append(akvInformerOptions, informers.WithTweakListOptions(func(options *metav1.ListOptions) {
 			options.LabelSelector = labelSelectorAppender(options.LabelSelector, objectLabelSet)
 		}))


### PR DESCRIPTION
kube informer should not use the object selector to be able to list and get all secrets.