### PR TITLE
Authentication service secret efficiency change

### DIFF
--- a/cmd/azure-keyvault-secrets-webhook/pod.go
+++ b/cmd/azure-keyvault-secrets-webhook/pod.go
@@ -112,6 +112,7 @@ func (p podWebHook) mutateContainers(ctx context.Context, containers []corev1.Co
 	mutated := false
 
 	for i, container := range containers {
+		useAuthService := p.useAuthService
 		klog.InfoS("found container to mutate", "container", klog.KRef(p.namespace, container.Name))
 
 		var envVars []corev1.EnvVar


### PR DESCRIPTION
Moved the creation of the authentication service secret out of mutate containers. Before it was attempting to create an identical secret for each container and init container. The end result was a single secret but there was quite a bit of time spent spinning over the containers checking to see if the secret (which was already created) was there. This change moves it outside mutateContainers resulting in a single attempt instead of container count + init container count attempts. 
Ex. If you have 5 containers and 3 init containers it would try 7 times before, it now does it once.
In our cluster this was causing the webhook to timeout on a large pod with many containers