### PR TITLE
Pass environmental key vault suffix to client

### DIFF
--- a/cmd/azure-keyvault-env/authentication.go
+++ b/cmd/azure-keyvault-env/authentication.go
@@ -87,17 +87,17 @@ func createMtlsClient(clientCertDir string) (*http.Client, error) {
 	return client, nil
 }
 
-func getCredentials() (azure.LegacyTokenCredential, error) {
+func getCredentials() (azure.LegacyTokenCredential, string, error) {
 	provider, err := credentialprovider.NewFromEnvironment()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create credentials provider for azure key vault, error: %w", err)
+		return nil, "", fmt.Errorf("failed to create credentials provider for azure key vault, error: %w", err)
 	}
 
 	creds, err := provider.GetAzureKeyVaultCredentials()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get credentials for azure key vault, error: %w", err)
+		return nil, "", fmt.Errorf("failed to get credentials for azure key vault, error: %w", err)
 	}
-	return creds, nil
+	return creds, provider.GetAzureKeyVaultDNSSuffix(), nil
 }
 
 func getCredentialsAuthService(authServiceAddress string, authServiceValidationAddress string, clientCertDir string) (azure.LegacyTokenCredential, error) {

--- a/pkg/azure/credentialprovider/akv.go
+++ b/pkg/azure/credentialprovider/akv.go
@@ -84,6 +84,11 @@ func (c CloudConfigCredentialProvider) GetAzureKeyVaultCredentials() (azure.Lega
 	return azure.NewLegacyTokenCredentialAdal(token), nil
 }
 
+// GetAzureKeyVaultDNSSuffix returns the environment specific Azure Key Vault DNS suffix
+func (c CloudConfigCredentialProvider) GetAzureKeyVaultDNSSuffix() string {
+	return c.environment.KeyVaultDNSSuffix
+}
+
 // GetAzureKeyVaultCredentials will get Azure credentials
 func (c EnvironmentCredentialProvider) GetAzureKeyVaultCredentials() (azure.LegacyTokenCredential, error) {
 	azureToken, err := getCredentials(c.envSettings, c.envSettings.Environment.ResourceIdentifiers.KeyVault)
@@ -92,7 +97,11 @@ func (c EnvironmentCredentialProvider) GetAzureKeyVaultCredentials() (azure.Lega
 	}
 
 	return azure.NewLegacyTokenCredentialAdal(azureToken.token), nil
+}
 
+// GetAzureKeyVaultDNSSuffix returns the environment specific Azure Key Vault DNS suffix
+func (c EnvironmentCredentialProvider) GetAzureKeyVaultDNSSuffix() string {
+	return c.envSettings.Environment.KeyVaultDNSSuffix
 }
 
 func getCredentialsAzidentity() (azure.LegacyTokenCredential, error) {
@@ -107,4 +116,9 @@ func getCredentialsAzidentity() (azure.LegacyTokenCredential, error) {
 // GetAzureKeyVaultCredentials will get Azure credentials
 func (c AzidentityCredentialProvider) GetAzureKeyVaultCredentials() (azure.LegacyTokenCredential, error) {
 	return getCredentialsAzidentity()
+}
+
+// GetAzureKeyVaultDNSSuffix returns the environment specific Azure Key Vault DNS suffix
+func (c AzidentityCredentialProvider) GetAzureKeyVaultDNSSuffix() string {
+	return c.envSettings.Environment.KeyVaultDNSSuffix
 }

--- a/pkg/azure/credentialprovider/provider.go
+++ b/pkg/azure/credentialprovider/provider.go
@@ -62,6 +62,7 @@ type CredentialProvider interface {
 	GetAzureKeyVaultCredentials() (myazure.LegacyTokenCredential, error)
 	GetAcrCredentials(image string) (k8sCredentialProvider.DockerConfigEntry, error)
 	// IsAcrRegistry(image string) bool
+	GetAzureKeyVaultDNSSuffix() string
 }
 
 // UserAssignedManagedIdentityProvider provides credentials for Azure using managed identity

--- a/pkg/azure/keyvault/client/service_test.go
+++ b/pkg/azure/keyvault/client/service_test.go
@@ -88,7 +88,7 @@ func TestIntegrationGetSecret(t *testing.T) {
 		t.Error(err)
 	}
 
-	srvc := NewService(creds)
+	srvc := NewService(creds, provider.GetAzureKeyVaultDNSSuffix())
 	akvSecret := newAzureKeyVaultSecret("mySecret", "akv2k8s-test", "my-secret")
 
 	secret, err := srvc.GetSecret(&akvSecret.Spec.Vault)
@@ -115,7 +115,7 @@ func TestIntegrationEnvironmentGetSecret(t *testing.T) {
 		t.Error(err)
 	}
 
-	srvc := NewService(creds)
+	srvc := NewService(creds, provider.GetAzureKeyVaultDNSSuffix())
 	akvSecret := newAzureKeyVaultSecret("mySecret", "akv2k8s-test", "my-secret")
 
 	secret, err := srvc.GetSecret(&akvSecret.Spec.Vault)


### PR DESCRIPTION
The DNS suffix for key vault differs among different Azure clouds.
This PR adds back the support to environmental specific key vault suffix after migrating to MSAL.