### PR TITLE
Added SecurityContext capabilities.

### DIFF
--- a/cmd/azure-keyvault-secrets-webhook/main.go
+++ b/cmd/azure-keyvault-secrets-webhook/main.go
@@ -205,6 +205,14 @@ func initConfig() {
 	viper.SetDefault("use_auth_service", true)
 	viper.SetDefault("metrics_enabled", false)
 	viper.SetDefault("env_injector_exec_dir", "/azure-keyvault/")
+
+	viper.SetDefault("webhook_container_security_context_read_only", false)
+	viper.SetDefault("webhook_container_security_context_non_root", false)
+	viper.SetDefault("webhook_container_security_context_user_uid", 1000)
+	viper.SetDefault("webhook_container_security_context_group_gid", 3000)
+	viper.SetDefault("webhook_container_security_context_privileged", true)
+	viper.SetDefault("webhook_pod_spec_security_context_non_root", false)
+
 	viper.AutomaticEnv()
 }
 

--- a/cmd/azure-keyvault-secrets-webhook/pod.go
+++ b/cmd/azure-keyvault-secrets-webhook/pod.go
@@ -281,6 +281,7 @@ func (p podWebHook) mutatePodSpec(ctx context.Context, pod *corev1.Pod) error {
 	podSpec.SecurityContext = &corev1.PodSecurityContext{
 		RunAsNonRoot: &[]bool{viper.GetBool("webhook_pod_spec_security_context_non_root")}[0],
 	}
+
 	if p.useAuthService {
 		klog.InfoS("creating client certificate to use with auth service", klog.KRef(p.namespace, pod.Name))
 		authServiceSecret, err = p.authService.NewPodSecret(pod, p.namespace, p.mutationID)


### PR DESCRIPTION
Related to issue 282: https://github.com/SparebankenVest/azure-key-vault-to-kubernetes/issues/282

We managed to get this to work on our side by hardcoding the following in `pod.go`:

`SecurityContext: &corev1.SecurityContext{ ->`
			`Capabilities: &corev1.Capabilities{`
				`Drop: []corev1.Capability{"ALL"},`
			`},`
			`ReadOnlyRootFilesystem: &[]bool{true}[0],`
			`RunAsNonRoot:           &[]bool{true}[0],`
			`RunAsUser:              &[]int64{10000}[0],`
			`RunAsGroup:             &[]int64{10000}[0],`
			`Privileged:             &[]bool{false}[0],`
		`},`
`podSpec.SecurityContext = &corev1.PodSecurityContext{`
		`RunAsNonRoot: &[]bool{true}[0],`
	`}`

Then, we made it configurable with `viper` in `cmd/azure-keyvault-secrets-webhooks/main.go/initConfig`.

The values there are the default ones (so if you use them, the issue will persist -> you won't see `securityContext`, etc.)

You need to use these values:

`webhook_container_security_context_read_only = true`
`webhook_container_security_context_non_root = true`
`webhook_container_security_context_user_uid = 10000`
`webhook_container_security_context_group_gid = 10000`
`webhook_container_security_context_privileged = false`
`webhook_pod_spec_security_context_non_root = true`