### PR TITLE
Don't automount the service account token in webhook injected containers

### DIFF
--- a/cmd/azure-keyvault-secrets-webhook/main.go
+++ b/cmd/azure-keyvault-secrets-webhook/main.go
@@ -212,7 +212,6 @@ func initConfig() {
 	viper.SetDefault("webhook_container_security_context_user_uid", 1000)
 	viper.SetDefault("webhook_container_security_context_group_gid", 3000)
 	viper.SetDefault("webhook_container_security_context_privileged", true)
-	viper.SetDefault("webhook_pod_spec_security_context_non_root", false)
 
 	viper.AutomaticEnv()
 }

--- a/cmd/azure-keyvault-secrets-webhook/pod.go
+++ b/cmd/azure-keyvault-secrets-webhook/pod.go
@@ -63,7 +63,7 @@ func (p podWebHook) getInitContainers() []corev1.Container {
 	cmd := fmt.Sprintf("cp /usr/local/bin/%s %s", injectorExecutable, p.injectorDir)
 
 	container := corev1.Container{
-                AutomountServiceAccountToken: &[]bool{false}[0]
+                AutomountServiceAccountToken: &[]bool{false}[0],
 		Name:            "copy-azurekeyvault-env",
 		Image:           viper.GetString("azurekeyvault_env_image"),
 		ImagePullPolicy: corev1.PullPolicy(viper.GetString("webhook_container_image_pull_policy")),

--- a/cmd/azure-keyvault-secrets-webhook/pod.go
+++ b/cmd/azure-keyvault-secrets-webhook/pod.go
@@ -63,6 +63,7 @@ func (p podWebHook) getInitContainers() []corev1.Container {
 	cmd := fmt.Sprintf("cp /usr/local/bin/%s %s", injectorExecutable, p.injectorDir)
 
 	container := corev1.Container{
+                AutomountServiceAccountToken: &[]bool{false}[0]
 		Name:            "copy-azurekeyvault-env",
 		Image:           viper.GetString("azurekeyvault_env_image"),
 		ImagePullPolicy: corev1.PullPolicy(viper.GetString("webhook_container_image_pull_policy")),

--- a/cmd/azure-keyvault-secrets-webhook/pod.go
+++ b/cmd/azure-keyvault-secrets-webhook/pod.go
@@ -279,9 +279,6 @@ func (p podWebHook) mutatePodSpec(ctx context.Context, pod *corev1.Pod) error {
 	var err error
 	podSpec := &pod.Spec
 	podSpec.AutomountServiceAccountToken = &[]bool{false}[0]
-	podSpec.SecurityContext = &corev1.PodSecurityContext{
-		RunAsNonRoot: &[]bool{viper.GetBool("webhook_pod_spec_security_context_non_root")}[0],
-	}
 
 	if p.useAuthService {
 		klog.InfoS("creating client certificate to use with auth service", klog.KRef(p.namespace, pod.Name))

--- a/cmd/azure-keyvault-secrets-webhook/pod.go
+++ b/cmd/azure-keyvault-secrets-webhook/pod.go
@@ -63,7 +63,6 @@ func (p podWebHook) getInitContainers() []corev1.Container {
 	cmd := fmt.Sprintf("cp /usr/local/bin/%s %s", injectorExecutable, p.injectorDir)
 
 	container := corev1.Container{
-                AutomountServiceAccountToken: &[]bool{false}[0],
 		Name:            "copy-azurekeyvault-env",
 		Image:           viper.GetString("azurekeyvault_env_image"),
 		ImagePullPolicy: corev1.PullPolicy(viper.GetString("webhook_container_image_pull_policy")),
@@ -279,6 +278,7 @@ func (p podWebHook) mutatePodSpec(ctx context.Context, pod *corev1.Pod) error {
 	var authServiceSecret *corev1.Secret
 	var err error
 	podSpec := &pod.Spec
+        podSpec.AutomountServiceAccountToken = &[]bool{false}[0]
 	podSpec.SecurityContext = &corev1.PodSecurityContext{
 		RunAsNonRoot: &[]bool{viper.GetBool("webhook_pod_spec_security_context_non_root")}[0],
 	}

--- a/cmd/azure-keyvault-secrets-webhook/pod.go
+++ b/cmd/azure-keyvault-secrets-webhook/pod.go
@@ -278,7 +278,7 @@ func (p podWebHook) mutatePodSpec(ctx context.Context, pod *corev1.Pod) error {
 	var authServiceSecret *corev1.Secret
 	var err error
 	podSpec := &pod.Spec
-        podSpec.AutomountServiceAccountToken = &[]bool{false}[0]
+	podSpec.AutomountServiceAccountToken = &[]bool{false}[0]
 	podSpec.SecurityContext = &corev1.PodSecurityContext{
 		RunAsNonRoot: &[]bool{viper.GetBool("webhook_pod_spec_security_context_non_root")}[0],
 	}


### PR DESCRIPTION
The token is not used in these containers, because they are just doing a file copy; so we don't need to automount it