### PR TITLE
azure-keyvault-controller: restrict Kubernetes event generation to changes

### DIFF
--- a/cmd/azure-keyvault-controller/controller/azureKeyVaultSecret.go
+++ b/cmd/azure-keyvault-controller/controller/azureKeyVaultSecret.go
@@ -135,7 +135,6 @@ func (c *Controller) syncDeletedAzureKeyVaultSecret(key string) error {
 		}
 
 		klog.V(4).InfoS("sync successful", "azurekeyvaultsecret", klog.KObj(akvs), "secret", klog.KObj(secret))
-		c.recorder.Event(secret, corev1.EventTypeNormal, SuccessSynced, MessageAzureKeyVaultSecretSynced)
 		outputObject = secret
 	}
 
@@ -146,7 +145,6 @@ func (c *Controller) syncDeletedAzureKeyVaultSecret(key string) error {
 		}
 
 		klog.V(4).InfoS("sync successful", "azurekeyvaultsecret", klog.KObj(akvs), "configmap", klog.KObj(cm))
-		c.recorder.Event(cm, corev1.EventTypeNormal, SuccessSynced, MessageAzureKeyVaultSecretSynced)
 		outputObject = cm
 	}
 
@@ -179,7 +177,6 @@ func (c *Controller) syncAzureKeyVaultSecret(key string) error {
 		}
 
 		klog.V(4).InfoS("sync successful", "azurekeyvaultsecret", klog.KObj(akvs), "secret", klog.KObj(secret))
-		c.recorder.Event(secret, corev1.EventTypeNormal, SuccessSynced, MessageAzureKeyVaultSecretSynced)
 		outputObject = secret
 	}
 
@@ -190,7 +187,6 @@ func (c *Controller) syncAzureKeyVaultSecret(key string) error {
 		}
 
 		klog.V(4).InfoS("sync successful", "azurekeyvaultsecret", klog.KObj(akvs), "configmap", klog.KObj(cm))
-		c.recorder.Event(cm, corev1.EventTypeNormal, SuccessSynced, MessageAzureKeyVaultSecretSynced)
 		outputObject = cm
 	}
 
@@ -258,6 +254,7 @@ func (c *Controller) syncAzureKeyVault(key string) error {
 				}
 
 				secretName = secret.Name
+				c.recorder.Event(akvs, corev1.EventTypeNormal, SuccessSynced, MessageAzureKeyVaultSecretSyncedWithAzureKeyVault)
 				klog.InfoS("secret changed - any resources (like pods) using this secret must be restarted to pick up the new value - details: https://github.com/kubernetes/kubernetes/issues/22368", "azurekeyvaultsecret", klog.KObj(secret), "secret", klog.KObj(akvs))
 			}
 		}
@@ -299,6 +296,7 @@ func (c *Controller) syncAzureKeyVault(key string) error {
 					return fmt.Errorf("failed to update configmap, error: %+v", err)
 				}
 				cmName = cm.Name
+				c.recorder.Event(akvs, corev1.EventTypeNormal, SuccessSynced, MessageAzureKeyVaultSecretSyncedWithAzureKeyVault)
 				klog.InfoS("configmap changed - any resources (like pods) using this configmap must be restarted to pick up the new value - details: https://github.com/kubernetes/kubernetes/issues/22368", "azurekeyvaultsecret", klog.KObj(akvs), "configmap", klog.KObj(cm))
 			}
 		}
@@ -310,7 +308,6 @@ func (c *Controller) syncAzureKeyVault(key string) error {
 	}
 
 	klog.V(4).InfoS("sync successful", "azurekeyvaultsecret", klog.KObj(akvs))
-	c.recorder.Event(akvs, corev1.EventTypeNormal, SuccessSynced, MessageAzureKeyVaultSecretSyncedWithAzureKeyVault)
 	return nil
 }
 

--- a/cmd/azure-keyvault-controller/controller/configmap.go
+++ b/cmd/azure-keyvault-controller/controller/configmap.go
@@ -104,7 +104,7 @@ func (c *Controller) getOrCreateKubernetesConfigMap(akvs *akv.AzureKeyVaultSecre
 			if err = c.updateAzureKeyVaultSecretStatusForConfigMap(akvs, getMD5HashOfStringValues(cmValues)); err != nil {
 				return nil, fmt.Errorf("failed to update status for azurekeyvaultsecret %s, error: %+v", akvs.Name, err)
 			}
-
+			c.recorder.Event(cm, corev1.EventTypeNormal, SuccessSynced, MessageAzureKeyVaultSecretSynced)
 			return cm, nil
 		}
 	}
@@ -131,6 +131,7 @@ func (c *Controller) getOrCreateKubernetesConfigMap(akvs *akv.AzureKeyVaultSecre
 		if cm, err = c.kubeclientset.CoreV1().ConfigMaps(akvs.Namespace).Create(context.TODO(), createNewConfigMap(akvs, cmValues), metav1.CreateOptions{}); err != nil {
 			return nil, err
 		}
+		c.recorder.Event(cm, corev1.EventTypeNormal, SuccessSynced, MessageAzureKeyVaultSecretSynced)
 		return cm, nil
 	}
 
@@ -145,6 +146,7 @@ func (c *Controller) getOrCreateKubernetesConfigMap(akvs *akv.AzureKeyVaultSecre
 		cm, err = c.kubeclientset.CoreV1().ConfigMaps(akvs.Namespace).Update(context.TODO(), updatedCM, metav1.UpdateOptions{})
 		if err == nil {
 			klog.InfoS("configmap updated", "azurekeyvaultsecret", klog.KObj(akvs), "configmap", klog.KObj(cm))
+			c.recorder.Event(cm, corev1.EventTypeNormal, SuccessSynced, MessageAzureKeyVaultSecretSynced)
 		}
 	}
 

--- a/cmd/azure-keyvault-controller/controller/secret.go
+++ b/cmd/azure-keyvault-controller/controller/secret.go
@@ -101,7 +101,7 @@ func (c *Controller) getOrCreateKubernetesSecret(akvs *akv.AzureKeyVaultSecret) 
 			if err = c.updateAzureKeyVaultSecretStatusForSecret(akvs, getMD5HashOfByteValues(secretValues)); err != nil {
 				return nil, err
 			}
-
+			c.recorder.Event(secret, corev1.EventTypeNormal, SuccessSynced, MessageAzureKeyVaultSecretSynced)
 			return secret, nil
 		}
 	}
@@ -128,6 +128,7 @@ func (c *Controller) getOrCreateKubernetesSecret(akvs *akv.AzureKeyVaultSecret) 
 		if secret, err = c.kubeclientset.CoreV1().Secrets(akvs.Namespace).Create(context.TODO(), createNewSecret(akvs, secretValues), metav1.CreateOptions{}); err != nil {
 			return nil, err
 		}
+		c.recorder.Event(secret, corev1.EventTypeNormal, SuccessSynced, MessageAzureKeyVaultSecretSynced)
 		return secret, nil
 	}
 
@@ -141,6 +142,7 @@ func (c *Controller) getOrCreateKubernetesSecret(akvs *akv.AzureKeyVaultSecret) 
 		secret, err = c.kubeclientset.CoreV1().Secrets(akvs.Namespace).Update(context.TODO(), updatedSecret, metav1.UpdateOptions{})
 		if err == nil {
 			klog.InfoS("secret updated", "azurekeyvaultsecret", klog.KObj(akvs), "secret", klog.KObj(secret))
+			c.recorder.Event(secret, corev1.EventTypeNormal, SuccessSynced, MessageAzureKeyVaultSecretSynced)
 		}
 	}
 


### PR DESCRIPTION
Currently, a Kubernetes event is generated for each object at every sync loop in the controller. Events are generated even when there is no difference between the secret in Azure Key Vault and content of the secret/configMap. This means that with a high number of secrets, a storm of events are sent to the cluster at every sync loop.

This PR reshuffles the event generation a little, so events are only generated if there is an update to the secret because of a change in the Key Vault secret, or if a secret/configMap object is created or modified.

The reasoning is that there is no need for such a high number of events to be sent, and that Kubernetes events should denote a state change in the system.