### PR TITLE
Add support for setting seccomp profile and allow privilege escalatio…

### DIFF
--- a/cmd/azure-keyvault-secrets-webhook/pod.go
+++ b/cmd/azure-keyvault-secrets-webhook/pod.go
@@ -82,12 +82,20 @@ func (p podWebHook) getInitContainers() []corev1.Container {
 			},
 		},
 	}
+        if viper.IsSet("webhook_container_security_context_allow_privilege_escalation") {
+                container.SecurityContext.AllowPrivilegeEscalation = &[]bool{viper.GetBool("webhook_container_security_context_allow_privilege_escalation")}[0]
+        }
 	if viper.IsSet("webhook_container_security_context_user_uid") {
 		container.SecurityContext.RunAsUser = &[]int64{viper.GetInt64("webhook_container_security_context_user_uid")}[0]
 	}
 	if viper.IsSet("webhook_container_security_context_group_gid") {
 		container.SecurityContext.RunAsGroup = &[]int64{viper.GetInt64("webhook_container_security_context_group_gid")}[0]
 	}
+        if viper.IsSet("webhook_container_security_context_seccomp_runtime_default") && viper.GetBool("webhook_container_security_context_seccomp_runtime_default") {
+                container.SecurityContext.SeccompProfile = &corev1.SeccompProfile{
+                        Type: corev1.SeccompProfileTypeRuntimeDefault,
+                }
+        }
 
 	return []corev1.Container{container}
 }

--- a/cmd/azure-keyvault-secrets-webhook/pod.go
+++ b/cmd/azure-keyvault-secrets-webhook/pod.go
@@ -82,20 +82,20 @@ func (p podWebHook) getInitContainers() []corev1.Container {
 			},
 		},
 	}
-        if viper.IsSet("webhook_container_security_context_allow_privilege_escalation") {
-                container.SecurityContext.AllowPrivilegeEscalation = &[]bool{viper.GetBool("webhook_container_security_context_allow_privilege_escalation")}[0]
-        }
+	if viper.IsSet("webhook_container_security_context_allow_privilege_escalation") {
+		container.SecurityContext.AllowPrivilegeEscalation = &[]bool{viper.GetBool("webhook_container_security_context_allow_privilege_escalation")}[0]
+	}
 	if viper.IsSet("webhook_container_security_context_user_uid") {
 		container.SecurityContext.RunAsUser = &[]int64{viper.GetInt64("webhook_container_security_context_user_uid")}[0]
 	}
 	if viper.IsSet("webhook_container_security_context_group_gid") {
 		container.SecurityContext.RunAsGroup = &[]int64{viper.GetInt64("webhook_container_security_context_group_gid")}[0]
 	}
-        if viper.IsSet("webhook_container_security_context_seccomp_runtime_default") && viper.GetBool("webhook_container_security_context_seccomp_runtime_default") {
-                container.SecurityContext.SeccompProfile = &corev1.SeccompProfile{
-                        Type: corev1.SeccompProfileTypeRuntimeDefault,
-                }
-        }
+	if viper.IsSet("webhook_container_security_context_seccomp_runtime_default") && viper.GetBool("webhook_container_security_context_seccomp_runtime_default") {
+		container.SecurityContext.SeccompProfile = &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		}
+	}
 
 	return []corev1.Container{container}
 }


### PR DESCRIPTION
…n security context values

This adds support for 2 new configuration options to control the injected container's security context:

```
      WEBHOOK_CONTAINER_SECURITY_CONTEXT_ALLOW_PRIVILEGE_ESCALATION: "false"
      WEBHOOK_CONTAINER_SECURITY_CONTEXT_SECCOMP_RUNTIME_DEFAULT: "true"
```

Both of these are optional settings. The first; if defined, adds the `allowPrivilegeEscalation` field to the `securityContext` spec of the initContainer. The second; if defined, *and*  set true, adds the `seccompProfile` field to the `securityContext` spec of the initContainer with `type: runtime/default` value pre-defined.