### PR TITLE
Use registry authentication for azure sp credentials, when authType i…

### DIFF
--- a/cmd/azure-keyvault-controller/main.go
+++ b/cmd/azure-keyvault-controller/main.go
@@ -102,7 +102,10 @@ func main() {
 
 	if logFormat == "json" {
 		loggerFactory := jsonlogs.Factory{}
-		logger, _ := loggerFactory.Create(logConfig.LoggingConfiguration{}, logConfig.LoggingOptions{})
+		logger, _ := loggerFactory.Create(*logConfig.NewLoggingConfiguration(), logConfig.LoggingOptions{
+			ErrorStream: os.Stderr,
+			InfoStream:  os.Stdout,
+		})
 		klog.SetLogger(logger)
 	}
 	klog.InfoS("log settings", "format", logFormat, "level", flag.Lookup("v").Value)

--- a/cmd/azure-keyvault-env/environment.go
+++ b/cmd/azure-keyvault-env/environment.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	envLookupRegex = `^([a-zA-Z0-9]([a-zA-Z0-9-]{0,239}[a-zA-Z0-9])?)@azurekeyvault(\?([a-zA-Z_][a-zA-Z0-9_\.]*)?)?$`
+	envLookupRegex = `^([a-zA-Z0-9]([a-zA-Z0-9-]{0,253}[a-zA-Z0-9])?)@azurekeyvault(\?([a-zA-Z_][a-zA-Z0-9_\.]*)?)?$`
 )
 
 type EnvSecret struct {

--- a/cmd/azure-keyvault-env/environment.go
+++ b/cmd/azure-keyvault-env/environment.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	envLookupRegex = `^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)@azurekeyvault(\?([a-zA-Z_][a-zA-Z0-9_\.]*)?)?$`
+	envLookupRegex = `^([a-zA-Z0-9]([a-zA-Z0-9-]{0,239}[a-zA-Z0-9])?)@azurekeyvault(\?([a-zA-Z_][a-zA-Z0-9_\.]*)?)?$`
 )
 
 type EnvSecret struct {

--- a/cmd/azure-keyvault-env/main.go
+++ b/cmd/azure-keyvault-env/main.go
@@ -157,7 +157,10 @@ func main() {
 
 	if logFormat == "json" {
 		loggerFactory := jsonlogs.Factory{}
-		logger, _ := loggerFactory.Create(logConfig.LoggingConfiguration{}, logConfig.LoggingOptions{})
+		logger, _ := loggerFactory.Create(*logConfig.NewLoggingConfiguration(), logConfig.LoggingOptions{
+			ErrorStream: os.Stderr,
+			InfoStream:  os.Stdout,
+		})
 		klog.SetLogger(logger)
 	}
 

--- a/cmd/azure-keyvault-secrets-webhook/main.go
+++ b/cmd/azure-keyvault-secrets-webhook/main.go
@@ -319,7 +319,7 @@ func main() {
 	wg := new(sync.WaitGroup)
 	wg.Add(2)
 
-	config.registry = registry.NewRegistry(config.cloudConfig)
+	config.registry = registry.NewRegistry(config.authType, config.credentialProvider)
 
 	createHTTPEndpoint(wg, config.httpPort, config.useAuthService, config.authService)
 	createMTLSEndpoint(wg, config.mtlsPort, config.useAuthService, config.authService)

--- a/cmd/azure-keyvault-secrets-webhook/main.go
+++ b/cmd/azure-keyvault-secrets-webhook/main.go
@@ -231,7 +231,11 @@ func main() {
 
 	if params.logFormat == "json" {
 		loggerFactory := jsonlogs.Factory{}
-		logger, _ := loggerFactory.Create(logConfig.LoggingConfiguration{}, logConfig.LoggingOptions{})
+		logger, _ := loggerFactory.Create(*logConfig.NewLoggingConfiguration(), logConfig.LoggingOptions{
+			ErrorStream: os.Stderr,
+			InfoStream:  os.Stdout,
+		})
+
 		klog.SetLogger(logger)
 	}
 

--- a/pkg/azure/credentialprovider/acr.go
+++ b/pkg/azure/credentialprovider/acr.go
@@ -69,6 +69,11 @@ func (c CloudConfigCredentialProvider) GetAcrCredentials(image string) (k8sCrede
 		Password: "",
 	}
 
+	if !c.IsAcrRegistry(image) {
+		klog.V(4).Info("image not from acr, returning empty credentials")
+		return cred, nil
+	}
+
 	if c.config.UseManagedIdentityExtension {
 		klog.V(4).Info("using managed identity for acr credentials")
 		loginServer := parseACRLoginServerFromImage(image, c.environment)

--- a/pkg/docker/registry/registry.go
+++ b/pkg/docker/registry/registry.go
@@ -58,7 +58,7 @@ type Registry struct {
 }
 
 // NewRegistry creates and initializes registry
-func NewRegistry(authType string, credentialProvider credentialprovider.CredentialProvider) ImageRegistry { //, credentialProvider credentialprovider.CredentialProvider
+func NewRegistry(authType string, credentialProvider credentialprovider.CredentialProvider) ImageRegistry {
 	return &Registry{
 		authType:           authType,
 		imageCache:         cache.New(cache.NoExpiration, cache.NoExpiration),

--- a/pkg/docker/registry/registry_secret.go
+++ b/pkg/docker/registry/registry_secret.go
@@ -1,0 +1,46 @@
+package registry
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type secretType struct {
+	name    corev1.SecretType
+	key     string
+	marshal func(registry string, auth authn.AuthConfig) []byte
+}
+
+func (s *secretType) Create(namespace, name string, registry string, auth authn.AuthConfig) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Type: s.name,
+		Data: map[string][]byte{
+			s.key: s.marshal(registry, auth),
+		},
+	}
+}
+
+var dockerCfgSecretType = secretType{
+	name: corev1.SecretTypeDockercfg,
+	key:  corev1.DockerConfigKey,
+	marshal: func(target string, auth authn.AuthConfig) []byte {
+		return toJSON(map[string]authn.AuthConfig{target: auth})
+	},
+}
+
+func toJSON(obj any) []byte {
+	bites, err := json.Marshal(obj)
+
+	if err != nil {
+		fmt.Errorf("unable to json marshal: %w", err)
+	}
+	return bites
+}


### PR DESCRIPTION
…s azureCloudConfig

### Motivation
- Authentication failure against acr when using authtype azureCloudConfig and imagepullcredentials are not used https://github.com/SparebankenVest/azure-key-vault-to-kubernetes/issues/495
- Regex for environment names restricted to 61chars, https://github.com/SparebankenVest/azure-key-vault-to-kubernetes/issues/630

### Approach
- Authenticate with service principal credential inaddition to imagepull  secret when azure cloud configuration is used.
- Update enviroment var akvs name to match rfc1123 for dns label names used for kubernetes resource names. inccrease allowed regex chars to 253