### PR TITLE
Increase the length of the azure keyvault environment regex to 253 characters

### DIFF
--- a/cmd/azure-keyvault-env/environment.go
+++ b/cmd/azure-keyvault-env/environment.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	envLookupRegex = `^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)@azurekeyvault(\?([a-zA-Z_][a-zA-Z0-9_\.]*)?)?$`
+	envLookupRegex = `^([a-zA-Z0-9]([a-zA-Z0-9-]{0,253}[a-zA-Z0-9])?)@azurekeyvault(\?([a-zA-Z_][a-zA-Z0-9_\.]*)?)?$`
 )
 
 type EnvSecret struct {


### PR DESCRIPTION
Fixes #630