### PR TITLE
Prevent malformed url when vault dns suffix contains dot

### DIFF
--- a/pkg/azure/keyvault/client/service.go
+++ b/pkg/azure/keyvault/client/service.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"time"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/azcertificates"
 	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys"
@@ -65,7 +66,7 @@ func (a *azureKeyVaultService) vaultNameToURL(name string) string {
 	if suffix == "" {
 		suffix = "vault.azure.net"
 	}
-	return fmt.Sprintf("https://%s.%s", name, suffix)
+	return fmt.Sprintf("https://%s.%s", strings.TrimSuffix(name, "."), strings.TrimPrefix(suffix, "."))
 }
 
 // GetSecret download secrets from Azure Key Vault


### PR DESCRIPTION
I've seen disagreement on whether the vault dns suffix should contain a dot prefix or not. You can check both az cli and powershell modules and see they don't agree either. This change should make it work either way.