### PR TITLE
Set ReadOnlyRootFilesystem, Memory, and CPU Limits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ LABEL org.label-schema.url=$VCS_URL
 LABEL org.label-schema.description="A Kubernetes Mutating Admission Webhook that adds an init container to a pod that will inject environment variables from Azure Key Vault"
 LABEL org.label-schema.vendor="Sparebanken Vest"
 LABEL org.label-schema.author="Jon Arild Tørresdal"
+RUN apk update && apk upgrade
 
 COPY --from=builder /go/src/github.com/SparebankenVest/azure-key-vault-to-kubernetes/bin/azure-key-vault-to-kubernetes/azure-keyvault-secrets-webhook /usr/local/bin/
 ENV DEBUG false
@@ -57,6 +58,7 @@ LABEL org.label-schema.url=$VCS_URL
 LABEL org.label-schema.description="A Kubernetes Mutating Admission Webhook that adds an init container to a pod that will inject environment variables from Azure Key Vault"
 LABEL org.label-schema.vendor="Sparebanken Vest"
 LABEL org.label-schema.author="Jon Arild Tørresdal"
+RUN apk update && apk upgrade
 
 COPY --from=builder /go/src/github.com/SparebankenVest/azure-key-vault-to-kubernetes/bin/azure-key-vault-to-kubernetes/azure-keyvault-controller /usr/local/bin/
 ENV DEBUG false
@@ -77,6 +79,7 @@ LABEL org.label-schema.url=$VCS_URL
 LABEL org.label-schema.description="A Kubernetes Mutating Admission Webhook that adds an init container to a pod that will inject environment variables from Azure Key Vault"
 LABEL org.label-schema.vendor="Sparebanken Vest"
 LABEL org.label-schema.author="Jon Arild Tørresdal"
+RUN apk update && apk upgrade
 
 COPY --from=builder /go/src/github.com/SparebankenVest/azure-key-vault-to-kubernetes/bin/azure-key-vault-to-kubernetes/azure-keyvault-env /usr/local/bin/
 ENV DEBUG false

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ LABEL org.label-schema.url=$VCS_URL
 LABEL org.label-schema.description="A Kubernetes Mutating Admission Webhook that adds an init container to a pod that will inject environment variables from Azure Key Vault"
 LABEL org.label-schema.vendor="Sparebanken Vest"
 LABEL org.label-schema.author="Jon Arild Tørresdal"
-RUN apk update && apk upgrade
 
 COPY --from=builder /go/src/github.com/SparebankenVest/azure-key-vault-to-kubernetes/bin/azure-key-vault-to-kubernetes/azure-keyvault-secrets-webhook /usr/local/bin/
 ENV DEBUG false
@@ -58,7 +57,6 @@ LABEL org.label-schema.url=$VCS_URL
 LABEL org.label-schema.description="A Kubernetes Mutating Admission Webhook that adds an init container to a pod that will inject environment variables from Azure Key Vault"
 LABEL org.label-schema.vendor="Sparebanken Vest"
 LABEL org.label-schema.author="Jon Arild Tørresdal"
-RUN apk update && apk upgrade
 
 COPY --from=builder /go/src/github.com/SparebankenVest/azure-key-vault-to-kubernetes/bin/azure-key-vault-to-kubernetes/azure-keyvault-controller /usr/local/bin/
 ENV DEBUG false
@@ -79,7 +77,6 @@ LABEL org.label-schema.url=$VCS_URL
 LABEL org.label-schema.description="A Kubernetes Mutating Admission Webhook that adds an init container to a pod that will inject environment variables from Azure Key Vault"
 LABEL org.label-schema.vendor="Sparebanken Vest"
 LABEL org.label-schema.author="Jon Arild Tørresdal"
-RUN apk update && apk upgrade
 
 COPY --from=builder /go/src/github.com/SparebankenVest/azure-key-vault-to-kubernetes/bin/azure-key-vault-to-kubernetes/azure-keyvault-env /usr/local/bin/
 ENV DEBUG false

--- a/cmd/azure-keyvault-secrets-webhook/main.go
+++ b/cmd/azure-keyvault-secrets-webhook/main.go
@@ -213,6 +213,8 @@ func initConfig() {
 	viper.SetDefault("webhook_container_security_context_allow_privilege_escalation", false)
 	viper.SetDefault("webhook_container_security_context_user_uid", 10000)
 	viper.SetDefault("webhook_container_security_context_read_only_root_fs", true)
+	viper.SetDefault("webhook_container_memory_limit", "512Mi")
+	viper.SetDefault("webhook_container_cpu_limit", "500m")
 
 	viper.AutomaticEnv()
 }

--- a/cmd/azure-keyvault-secrets-webhook/main.go
+++ b/cmd/azure-keyvault-secrets-webhook/main.go
@@ -207,9 +207,12 @@ func initConfig() {
 	viper.SetDefault("env_injector_exec_dir", "/azure-keyvault/")
 
 	viper.SetDefault("webhook_container_image_pull_policy", corev1.PullIfNotPresent)
-	viper.SetDefault("webhook_container_security_context_read_only", false)
-	viper.SetDefault("webhook_container_security_context_non_root", false)
-	viper.SetDefault("webhook_container_security_context_privileged", true)
+	viper.SetDefault("webhook_container_security_context_read_only", true)
+	viper.SetDefault("webhook_container_security_context_non_root", true)
+	viper.SetDefault("webhook_container_security_context_privileged", false)
+	viper.SetDefault("webhook_container_security_context_allow_privilege_escalation", false)
+	viper.SetDefault("webhook_container_security_context_user_uid", 10000)
+	viper.SetDefault("webhook_container_security_context_read_only_root_fs", true)
 
 	viper.AutomaticEnv()
 }

--- a/cmd/azure-keyvault-secrets-webhook/main.go
+++ b/cmd/azure-keyvault-secrets-webhook/main.go
@@ -207,14 +207,9 @@ func initConfig() {
 	viper.SetDefault("env_injector_exec_dir", "/azure-keyvault/")
 
 	viper.SetDefault("webhook_container_image_pull_policy", corev1.PullIfNotPresent)
-	viper.SetDefault("webhook_container_security_context_read_only", true)
-	viper.SetDefault("webhook_container_security_context_non_root", true)
-	viper.SetDefault("webhook_container_security_context_privileged", false)
-	viper.SetDefault("webhook_container_security_context_allow_privilege_escalation", false)
-	viper.SetDefault("webhook_container_security_context_user_uid", 10000)
-	viper.SetDefault("webhook_container_security_context_read_only_root_fs", true)
-	viper.SetDefault("webhook_container_memory_limit", "512Mi")
-	viper.SetDefault("webhook_container_cpu_limit", "500m")
+	viper.SetDefault("webhook_container_security_context_read_only", false)
+	viper.SetDefault("webhook_container_security_context_non_root", false)
+	viper.SetDefault("webhook_container_security_context_privileged", true)
 
 	viper.AutomaticEnv()
 }

--- a/cmd/azure-keyvault-secrets-webhook/main.go
+++ b/cmd/azure-keyvault-secrets-webhook/main.go
@@ -210,6 +210,7 @@ func initConfig() {
 	viper.SetDefault("webhook_container_security_context_read_only", false)
 	viper.SetDefault("webhook_container_security_context_non_root", false)
 	viper.SetDefault("webhook_container_security_context_privileged", true)
+	viper.SetDefault("webhook_container_security_context_read_only_root_fs", false)
 
 	viper.AutomaticEnv()
 }

--- a/cmd/azure-keyvault-secrets-webhook/pod.go
+++ b/cmd/azure-keyvault-secrets-webhook/pod.go
@@ -96,6 +96,9 @@ func (p podWebHook) getInitContainers() []corev1.Container {
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		}
 	}
+	if viper.IsSet("webhook_container_security_context_read_only_root_fs") {
+		container.SecurityContext.ReadOnlyRootFilesystem = &[]bool{viper.GetBool("webhook_container_security_context_read_only_root_fs")}[0]
+	}
 
 	return []corev1.Container{container}
 }

--- a/cmd/azure-keyvault-secrets-webhook/pod.go
+++ b/cmd/azure-keyvault-secrets-webhook/pod.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/SparebankenVest/azure-key-vault-to-kubernetes/cmd/azure-keyvault-secrets-webhook/auth"
@@ -99,6 +100,21 @@ func (p podWebHook) getInitContainers() []corev1.Container {
 	if viper.IsSet("webhook_container_security_context_read_only_root_fs") {
 		container.SecurityContext.ReadOnlyRootFilesystem = &[]bool{viper.GetBool("webhook_container_security_context_read_only_root_fs")}[0]
 	}
+
+	resourceList := corev1.ResourceList{}
+	if viper.IsSet(("webhook_container_memory_limit")) {
+		memory, err := resource.ParseQuantity(viper.GetString("webhook_container_memory_limit"))
+		if err == nil {
+			resourceList["memory"] = memory
+		}
+	}
+	if viper.IsSet(("webhook_container_cpu_limit")) {
+		cpu, err := resource.ParseQuantity(viper.GetString("webhook_container_cpu_limit"))
+		if err == nil {
+			resourceList["cpu"] = cpu
+		}
+	}
+	container.Resources.Limits = resourceList
 
 	return []corev1.Container{container}
 }


### PR DESCRIPTION
Added the following capabilities:

- Ability to set the `ReadOnlyRootFilesystem` flag
- Ability to set the memory limit on the container
- Ability to set the CPU limit on the container

We have had this running in production for about six months.